### PR TITLE
Fix: Also upload tft.py

### DIFF
--- a/sw-demo/upload.sh
+++ b/sw-demo/upload.sh
@@ -7,3 +7,4 @@ ampy -p $_PORT put ssd1306.py
 ampy -p $_PORT put i2c_scroll.py
 ampy -p $_PORT put ST7735.py
 ampy -p $_PORT put spi_rects.py
+ampy -p $_PORT put tft.py


### PR DESCRIPTION
As this is imported by spi_rects, it should also be uploaded to the board.